### PR TITLE
Adding adaptor for HPX serialization

### DIFF
--- a/code/utils/include/allscale/utils/serializer/arrays.h
+++ b/code/utils/include/allscale/utils/serializer/arrays.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#if !defined(ALLSCALE_WITH_HPX)
 #include "allscale/utils/serializer.h"
 
 #include <array>
@@ -53,3 +54,9 @@ namespace utils {
 
 } // end namespace utils
 } // end namespace allscale
+
+#else
+
+#include <hpx/runtime/serialization/array.hpp>
+
+#endif

--- a/code/utils/include/allscale/utils/serializer/strings.h
+++ b/code/utils/include/allscale/utils/serializer/strings.h
@@ -1,3 +1,7 @@
+#pragma once
+
+#if !defined(ALLSCALE_WITH_HPX)
+
 #include "allscale/utils/serializer.h"
 
 #include <string>
@@ -26,3 +30,9 @@ namespace utils {
 
 } // end namespace utils
 } // end namespace allscale
+
+#else
+
+#include <hpx/runtime/serialization/string.hpp>
+
+#endif

--- a/code/utils/include/allscale/utils/serializer/vectors.h
+++ b/code/utils/include/allscale/utils/serializer/vectors.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#if !defined(ALLSCALE_WITH_HPX)
 #include "allscale/utils/serializer.h"
 
 #include <vector>
@@ -57,3 +58,9 @@ namespace utils {
 
 } // end namespace utils
 } // end namespace allscale
+
+#else
+
+#include <hpx/runtime/serialization/vector.hpp>
+
+#endif


### PR DESCRIPTION
 - ArchiveWriter and ArchiveReader use the HPX archives to store data,
   if the type is not Allscale Serializable, it falls back to HPX
 - Helper serialization (arrays, strings and vectors) falls back to HPX