### PR TITLE
Making GridBox default ctor public

### DIFF
--- a/code/api/include/allscale/api/user/data/grid.h
+++ b/code/api/include/allscale/api/user/data/grid.h
@@ -203,9 +203,8 @@ namespace data {
 		point_type min;
 		point_type max;
 
-		GridBox() {}
-
 	public:
+		GridBox() {}
 
 		GridBox(coordinate_type N)
 			: min(0), max(N) {}


### PR DESCRIPTION
This is required for HPX serialization to work